### PR TITLE
fix localhost urls in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,31 +29,31 @@ Run the project with
 
 See the demo URLs:
 
-  - http://localhost:8080/spring-comparing-template-engines/jsp
-  - http://localhost:8080/spring-comparing-template-engines/freemarker
-  - http://localhost:8080/spring-comparing-template-engines/velocity
-  - http://localhost:8080/spring-comparing-template-engines/thymeleaf
-  - http://localhost:8080/spring-comparing-template-engines/jade
-  - http://localhost:8080/spring-comparing-template-engines/scalate
-  - http://localhost:8080/spring-comparing-template-engines/mustache
-  - http://localhost:8080/spring-comparing-template-engines/pebble
-  - http://localhost:8080/spring-comparing-template-engines/handlebars
-  - http://localhost:8080/spring-comparing-template-engines/jtwig
+  - <http://localhost:8080/jsp>
+  - <http://localhost:8080/freemarker>
+  - <http://localhost:8080/velocity>
+  - <http://localhost:8080/thymeleaf>
+  - <http://localhost:8080/jade>
+  - <http://localhost:8080/scalate>
+  - <http://localhost:8080/mustache>
+  - <http://localhost:8080/pebble>
+  - <http://localhost:8080/handlebars>
+  - <http://localhost:8080/jtwig>
 
 ## Benchmarking
 
 In case you want to benchmark the different template engines I would recommend using Apache HTTP server benchmarking tool or Siege an HTTP/HTTPS stress tester.
 You can try any of the following URLs.
 
-    $ ab -n 10000 -c 10 http://localhost:8080/spring-comparing-template-engines/jsp
-    $ ab -n 10000 -c 10 http://localhost:8080/spring-comparing-template-engines/velocity
-    $ ab -n 10000 -c 10 http://localhost:8080/spring-comparing-template-engines/freemarker
-    $ ab -n 10000 -c 10 http://localhost:8080/spring-comparing-template-engines/thymeleaf
-    $ ab -n 10000 -c 10 http://localhost:8080/spring-comparing-template-engines/mustache
-    $ ab -n 10000 -c 10 http://localhost:8080/spring-comparing-template-engines/jade
-    $ ab -n 10000 -c 10 http://localhost:8080/spring-comparing-template-engines/pebble
-    $ ab -n 10000 -c 10 http://localhost:8080/spring-comparing-template-engines/handlebars
-    $ ab -n 10000 -c 10 http://localhost:8080/spring-comparing-template-engines/jtwig
+    $ ab -n 10000 -c 10 http://localhost:8080/jsp
+    $ ab -n 10000 -c 10 http://localhost:8080/velocity
+    $ ab -n 10000 -c 10 http://localhost:8080/freemarker
+    $ ab -n 10000 -c 10 http://localhost:8080/thymeleaf
+    $ ab -n 10000 -c 10 http://localhost:8080/mustache
+    $ ab -n 10000 -c 10 http://localhost:8080/jade
+    $ ab -n 10000 -c 10 http://localhost:8080/pebble
+    $ ab -n 10000 -c 10 http://localhost:8080/handlebars
+    $ ab -n 10000 -c 10 http://localhost:8080/jtwig
 
 
 For creating the below benchmark results I used ApacheBench(Version 2.3) with the following settings:


### PR DESCRIPTION
Following the instructions to compile and run, the urls given in README.md did not work.
Instead of 
http://localhost:8080/spring-comparing-template-engines/jsp
I propose
http://localhost:8080/jsp

Additionally, I added brackets around the links to make them show as urls.